### PR TITLE
駒の移動アクション実装

### DIFF
--- a/app/components/parts/shogi/Board.vue
+++ b/app/components/parts/shogi/Board.vue
@@ -12,9 +12,10 @@
             :key="x"
           >
             <Piece
-              :y="1"
-              :x="1"
+              :y="y"
+              :x="x"
               :typeNumber="sq"
+              @updated="updated"
             />
           </td>
         </tr>
@@ -44,6 +45,16 @@ export default {
         [11, 9, 7, 6, 1, 6, 7, 9, 11]
       ]
     };
+  },
+  methods: {
+    updated(dragPoint, dropPoint) {
+      this.replacePiece(dragPoint, dropPoint);
+    },
+    replacePiece(dragPoint, dropPoint) {
+      const dragPiece = this.shogiBoard[dragPoint[0]][dragPoint[1]];
+      this.shogiBoard[dragPoint[0]].splice([dragPoint[1]], 1, 0);
+      this.shogiBoard[dropPoint[0]].splice([dropPoint[1]], 1, dragPiece);
+    }
   }
 };
 </script>

--- a/app/components/parts/shogi/pieces/Piece.vue
+++ b/app/components/parts/shogi/pieces/Piece.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
-    <img :src="imgSrc">
+    <img
+      draggable
+      @dragstart="dragStart([y, x])"
+      @drop="dropped([y, x])"
+      @dragover.prevent
+      @dragenter.prevent
+      :src="imgSrc"
+    >
   </div>
 </template>
 
@@ -47,6 +54,18 @@ export default {
         const fileName = type.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
         return `/images/pieces/${fileName}.png`;
       }
+    }
+  },
+  methods: {
+    dragStart(dragPoint) {
+      event.dataTransfer.setData("drag-point", dragPoint);
+    },
+    dropped(dropPoint) {
+      const dragPoint = event.dataTransfer
+        .getData("drag-point")
+        .split(",")
+        .map((x) => parseInt(x));
+      this.$emit("updated", dragPoint, dropPoint);
     }
   }
 };


### PR DESCRIPTION
## 1. 目的

駒の移動アクション実装

## 2. 概要

- ドラッグ操作に応じて、盤上の駒を操作する

![画面収録 2020-04-14 21 16 16 mov](https://user-images.githubusercontent.com/47295890/79224221-b0396600-7e95-11ea-933e-86570b3f2d00.gif)
