### PR TITLE
金将と銀将用移動可否判定メソッド実装

### DIFF
--- a/app/components/mixin/pieceMoveable.js
+++ b/app/components/mixin/pieceMoveable.js
@@ -34,6 +34,19 @@ export default {
       );
       return table;
     },
+    silverExploration(table, point) {
+      const directions = [
+        [-1, -1],
+        [-1, 0],
+        [-1, 1],
+        [1, 1],
+        [1, -1],
+      ];
+      directions.forEach((dir) =>
+        this.isPutDown(table, point[0] + dir[0], point[1] + dir[1])
+      );
+      return table;
+    },
     lanceExploration(table, point) {
       return this.repeat(table, point[0], point[1], [-1, 0]);
     },
@@ -49,6 +62,8 @@ export default {
           return this.bishopExploration;
         case 6:
           return this.goldExploration;
+        case 7:
+          return this.silverExploration;
         case 11:
           return this.lanceExploration;
         default:


### PR DESCRIPTION
## 1. 目的

金将と銀将用移動可否判定メソッド実装

## 2. 概要

- 金将用移動可否判定メソッド実装
- 銀将移動可否判定メソッド実装
![画面収録 2020-04-16 21 12 59 mov](https://user-images.githubusercontent.com/47295890/79455198-74360a80-8027-11ea-8d86-04d36e943e82.gif)
